### PR TITLE
chore: refer state bumps and remove init_size on metadata_key

### DIFF
--- a/programs/mythic_metadata/src/constants.rs
+++ b/programs/mythic_metadata/src/constants.rs
@@ -3,10 +3,10 @@ pub const COUNTER: &[u8] = b"counter";
 pub const METADATA_KEY: &[u8] = b"metadata_key";
 pub const METADATA: &[u8] = b"metadata";
 
-pub const MAX_NAME_LEN: usize = 50;
-pub const MAX_LABEL_LEN: usize = 30;
-pub const MAX_DESCRIPTION_LEN: usize = 100;
-pub const MAX_CONTENT_TYPE_LEN: usize = 50;
+pub const MAX_NAME_LEN: usize = 4 + 50;
+pub const MAX_LABEL_LEN: usize = 4 + 30;
+pub const MAX_DESCRIPTION_LEN: usize = 4 + 100;
+pub const MAX_CONTENT_TYPE_LEN: usize = 4 + 50;
 pub const MAX_VALUE_LEN: usize = 10000;
 pub const MAX_COLLECTIONS_PER_METADATA: usize = 100;
 pub const MAX_ITEMS_PER_COLLECTION: usize = 100;

--- a/programs/mythic_metadata/src/instructions/append/collection.rs
+++ b/programs/mythic_metadata/src/instructions/append/collection.rs
@@ -30,7 +30,7 @@ pub struct AppendMetadataCollection<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -39,7 +39,7 @@ pub struct AppendMetadataCollection<'info> {
             METADATA_KEY,
             &collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = collection_metadata_key.bump,
     )]
     pub collection_metadata_key: Account<'info, MetadataKey>,
     pub system_program: Program<'info, System>,

--- a/programs/mythic_metadata/src/instructions/append/item.rs
+++ b/programs/mythic_metadata/src/instructions/append/item.rs
@@ -28,7 +28,7 @@ pub struct AppendMetadataItem<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -37,7 +37,7 @@ pub struct AppendMetadataItem<'info> {
             METADATA_KEY,
             &collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = collection_metadata_key.bump,
     )]
     pub collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -46,7 +46,7 @@ pub struct AppendMetadataItem<'info> {
             METADATA_KEY,
             &item_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = item_metadata_key.bump,
     )]
     pub item_metadata_key: Account<'info, MetadataKey>,
 }

--- a/programs/mythic_metadata/src/instructions/auth/revoke.rs
+++ b/programs/mythic_metadata/src/instructions/auth/revoke.rs
@@ -28,7 +28,7 @@ pub struct RevokeCollectionUpdateAuthority<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -37,7 +37,7 @@ pub struct RevokeCollectionUpdateAuthority<'info> {
             METADATA_KEY,
             &collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = collection_metadata_key.bump,
     )]
     pub collection_metadata_key: Account<'info, MetadataKey>,
 }

--- a/programs/mythic_metadata/src/instructions/auth/set.rs
+++ b/programs/mythic_metadata/src/instructions/auth/set.rs
@@ -19,7 +19,7 @@ pub struct SetCollectionUpdateAuthority<'info> {
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
-        bump
+        bump = metadata.bump,
     )]
     pub metadata: Account<'info, Metadata>,
     #[account(
@@ -28,7 +28,7 @@ pub struct SetCollectionUpdateAuthority<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -37,7 +37,7 @@ pub struct SetCollectionUpdateAuthority<'info> {
             METADATA_KEY,
             &collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = collection_metadata_key.bump,
     )]
     pub collection_metadata_key: Account<'info, MetadataKey>,
 }

--- a/programs/mythic_metadata/src/instructions/create/metadata.rs
+++ b/programs/mythic_metadata/src/instructions/create/metadata.rs
@@ -38,7 +38,7 @@ pub struct CreateMetadata<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     pub system_program: Program<'info, System>,

--- a/programs/mythic_metadata/src/instructions/create/metadata_key.rs
+++ b/programs/mythic_metadata/src/instructions/create/metadata_key.rs
@@ -13,7 +13,12 @@ pub struct CreateMetadataKey<'info> {
     #[account(
         init,
         payer = payer,
-        space = MetadataKey::size(),
+        space = MetadataKey::size(
+            &args.name,
+            &args.label,
+            &args.description,
+            &args.content_type
+        ),
         seeds = [
             PREFIX,
             METADATA_KEY,

--- a/programs/mythic_metadata/src/instructions/remove/collection.rs
+++ b/programs/mythic_metadata/src/instructions/remove/collection.rs
@@ -19,7 +19,7 @@ pub struct RemoveMetadataCollection<'info> {
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
-        bump
+        bump = metadata.bump,
     )]
     pub metadata: Account<'info, Metadata>,
     #[account(
@@ -28,7 +28,7 @@ pub struct RemoveMetadataCollection<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -37,7 +37,7 @@ pub struct RemoveMetadataCollection<'info> {
             METADATA_KEY,
             &collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = collection_metadata_key.bump,
     )]
     pub collection_metadata_key: Account<'info, MetadataKey>,
 }

--- a/programs/mythic_metadata/src/instructions/remove/item.rs
+++ b/programs/mythic_metadata/src/instructions/remove/item.rs
@@ -19,7 +19,7 @@ pub struct RemoveMetadataItem<'info> {
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
-        bump
+        bump = metadata.bump,
     )]
     pub metadata: Account<'info, Metadata>,
     #[account(
@@ -28,7 +28,7 @@ pub struct RemoveMetadataItem<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -37,7 +37,7 @@ pub struct RemoveMetadataItem<'info> {
             METADATA_KEY,
             &collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = collection_metadata_key.bump,
     )]
     pub collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -46,7 +46,7 @@ pub struct RemoveMetadataItem<'info> {
             METADATA_KEY,
             &item_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = item_metadata_key.bump,
     )]
     pub item_metadata_key: Account<'info, MetadataKey>,
 }

--- a/programs/mythic_metadata/src/instructions/update/item.rs
+++ b/programs/mythic_metadata/src/instructions/update/item.rs
@@ -19,7 +19,7 @@ pub struct UpdateMetadataItem<'info> {
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
-        bump
+        bump = metadata.bump,
     )]
     pub metadata: Account<'info, Metadata>,
     #[account(
@@ -28,7 +28,7 @@ pub struct UpdateMetadataItem<'info> {
             METADATA_KEY,
             &root_collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = root_collection_metadata_key.bump,
     )]
     pub root_collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -37,7 +37,7 @@ pub struct UpdateMetadataItem<'info> {
             METADATA_KEY,
             &collection_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = collection_metadata_key.bump,
     )]
     pub collection_metadata_key: Account<'info, MetadataKey>,
     #[account(
@@ -46,7 +46,7 @@ pub struct UpdateMetadataItem<'info> {
             METADATA_KEY,
             &item_metadata_key.id.to_le_bytes()
         ],
-        bump,
+        bump = item_metadata_key.bump,
     )]
     pub item_metadata_key: Account<'info, MetadataKey>,
 }

--- a/programs/mythic_metadata/src/state/metadata_key.rs
+++ b/programs/mythic_metadata/src/state/metadata_key.rs
@@ -4,7 +4,6 @@ use crate::constants::*;
 use crate::errors::*;
 
 #[account]
-#[derive(InitSpace)]
 /// MetadataKey account defines a single metadata value
 pub struct MetadataKey {
     /// Id
@@ -15,20 +14,16 @@ pub struct MetadataKey {
     pub namespace_authority: Pubkey,
 
     /// Name of the metadata value represented by the MetadataKey
-    #[max_len(MAX_NAME_LEN)]
     pub name: String,
 
     /// User friendly label of the value represented by the MetadataKey
-    #[max_len(MAX_LABEL_LEN)]
     pub label: String,
 
     /// Description of the value represented by the MetadataKey
-    #[max_len(MAX_DESCRIPTION_LEN)]
     pub description: String,
 
     /// The type of the metadata described by the key
     /// e.g. string, number, image, metadata, metadata-collection etc.
-    #[max_len(MAX_CONTENT_TYPE_LEN)]
     pub content_type: String,
 
     /// Bump
@@ -36,8 +31,15 @@ pub struct MetadataKey {
 }
 
 impl MetadataKey {
-    pub fn size() -> usize {
-        8 + MetadataKey::INIT_SPACE
+    pub fn size(name: &str, label: &str, description: &str, content_type: &str) -> usize {
+        8 + // Anchor discriminator
+        8 + // ID
+        32 + // Namespace Authority
+        4 + name.len() + // Name
+        4 + label.len() + // Label
+        4 + description.len() + // Description
+        4 + content_type.len() + // Content Type
+        1 // bump
     }
 
     pub fn validate(name: &str, label: &str, description: &str, content_type: &str) -> Result<()> {


### PR DESCRIPTION
The `MetadataKey` account has variable sizing instead of referring the `MAX_SIZE` arg.