### PR TITLE
chore: Rearrange root collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7368e171b3a317885dc08ec0f74eed9d0ad6c726cc819593aed81440dca926"
+checksum = "47fe28365b33e8334dd70ae2f34a43892363012fe239cf37d2ee91693575b1f8"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f527df85a8cba3f2bea04e46ed71b66e525ea378c7fec538aa205f4520b73e31"
+checksum = "3c288d496168268d198d9b53ee9f4f9d260a55ba4df9877ea1d4486ad6109e0f"
 dependencies = [
  "anchor-syn",
  "bs58 0.5.1",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb1dc1845cf8636c2e046a274ca074dabd3884ac8ed11cc4ed64b7e8ef5a318"
+checksum = "49b77b6948d0eeaaa129ce79eea5bbbb9937375a9241d909ca8fb9e006bb6e90"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f382e41514c59a77ffa7bb1a47df9a0359564a749b6934485c742c11962e540"
+checksum = "4d20bb569c5a557c86101b944721d865e1fd0a4c67c381d31a44a84f07f84828"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473a122aeed3f6b666438236338d2ef7833ee5fdc5688e1baa80185d61088a53"
+checksum = "4cebd8d0671a3a9dc3160c48598d652c34c77de6be4d44345b8b514323284d57"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f88c7ffe2eb40aeac43ffd0d74a6671581158aedfaa0552330a2ef92fa5c889"
+checksum = "efb2a5eb0860e661ab31aff7bb5e0288357b176380e985bade4ccb395981b42d"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9b97c99dcec135aae0ff908c14bcfcd3e78cfc16a0c6f245135038f0e6d390"
+checksum = "04368b5abef4266250ca8d1d12f4dff860242681e4ec22b885dcfe354fd35aa1"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbece98f6ad9c37070edc0841326c9623a249346cd74f433e7cef69b14f7f31d"
+checksum = "e0bb0e0911ad4a70cab880cdd6287fe1e880a1a9d8e4e6defa8e9044b9796a6c"
 dependencies = [
  "anchor-syn",
  "borsh-derive-internal 0.10.3",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8badbe2648bc99a85ee05a7a5f9512e5e2af8ffac71476a69350cb278057ac53"
+checksum = "5ef415ff156dc82e9ecb943189b0cb241b3a6bfc26a180234dc21bd3ef3ce0cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41feb9c1cd9f4b0fad1c004fc8f289183f3ce27e9db38fa6e434470c716fb1e"
+checksum = "6620c9486d9d36a4389cab5e37dc34a42ed0bfaa62e6a75a2999ce98f8f2e373"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -173,22 +173,34 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang-idl"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29da81eae478b1bb846749b06b8a2cb9c6f9ed26ca793b0c916793fdf36adab"
+checksum = "31cf97b4e6f7d6144a05e435660fcf757dbc3446d38d0e2b851d11ed13625bba"
 dependencies = [
- "anchor-syn",
+ "anchor-lang-idl-spec",
  "anyhow",
+ "heck",
  "regex",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "anchor-lang-idl-spec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bdf143115440fe621bdac3a29a1f7472e09f6cd82b2aa569429a0c13f103838"
+dependencies = [
+ "anyhow",
+ "serde",
 ]
 
 [[package]]
 name = "anchor-syn"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac53f2378bc08e89e20c2b893c01986ffd34cfbc69a17e35bd6f754753e9fdad"
+checksum = "f99daacb53b55cfd37ce14d6c9905929721137fd4c67bbab44a19802aecb622f"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["programs/*"]
 resolver = "2"
 
 [workspace.dependencies]
-anchor-lang = "0.30.0"
+anchor-lang = "0.30.1"
 
 [profile.release]
 overflow-checks = true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.30.0",
+    "@coral-xyz/anchor": "^0.30.1",
     "@solana/web3.js": "1.91.8",
     "rpc-websockets": "7.11.0"
   },

--- a/programs/mythic_metadata/src/instructions/append/item.rs
+++ b/programs/mythic_metadata/src/instructions/append/item.rs
@@ -11,26 +11,26 @@ pub struct AppendMetadataItem<'info> {
     pub update_authority: Signer<'info>,
     #[account(
         mut,
-        constraint = metadata.collection.metadata_key_id.eq(&root_collection_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
+        constraint = metadata.metadata_key_id.eq(&metadata_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
         seeds = [
             PREFIX,
             METADATA,
-            root_collection_metadata_key.key().as_ref(),
+            metadata_metadata_key.key().as_ref(),
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
-        bump
+        bump = metadata.bump,
     )]
     pub metadata: Account<'info, Metadata>,
     #[account(
         seeds = [
             PREFIX,
             METADATA_KEY,
-            &root_collection_metadata_key.id.to_le_bytes()
+            &metadata_metadata_key.id.to_le_bytes()
         ],
-        bump = root_collection_metadata_key.bump,
+        bump = metadata_metadata_key.bump,
     )]
-    pub root_collection_metadata_key: Account<'info, MetadataKey>,
+    pub metadata_metadata_key: Account<'info, MetadataKey>,
     #[account(
         seeds = [
             PREFIX,
@@ -53,28 +53,24 @@ pub struct AppendMetadataItem<'info> {
 
 pub fn handler(ctx: Context<AppendMetadataItem>, args: AppendMetadataItemArgs) -> Result<()> {
     let metadata = &mut ctx.accounts.metadata;
-    let root_collection_metadata_key = &ctx.accounts.root_collection_metadata_key;
+    let metadata_metadata_key = &ctx.accounts.metadata_metadata_key;
     let collection_metadata_key = &ctx.accounts.collection_metadata_key;
     let item_metadata_key = &ctx.accounts.item_metadata_key;
     let update_authority = &ctx.accounts.update_authority;
 
     // Check if metadata item is to be appended in root collection
-    if check_collection_root_collection_equality(
-        root_collection_metadata_key,
-        collection_metadata_key,
-    ) {
-        verify_root_collection_update_authority(&metadata.collection, &update_authority.key())?;
+    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+        verify_metadata_update_authority(&metadata, &update_authority.key())?;
 
         match metadata
-            .collection
             .items
             .binary_search_by_key(&item_metadata_key.id, |item| item.metadata_key_id)
         {
             Ok(_) => return err!(MythicMetadataError::MetadataItemAlreadyExists),
             Err(item_index) => {
                 let slot = Clock::get()?.slot;
-                metadata.collection.update_slot = slot;
-                metadata.collection.items.insert(
+                metadata.update_slot = slot;
+                metadata.items.insert(
                     item_index,
                     MetadataItem {
                         metadata_key_id: item_metadata_key.id,
@@ -86,7 +82,7 @@ pub fn handler(ctx: Context<AppendMetadataItem>, args: AppendMetadataItemArgs) -
         };
     } else {
         let (collection_index, mut collection) = verify_collection_update_authority(
-            &metadata.collection,
+            &metadata,
             collection_metadata_key.id,
             &update_authority.key(),
         )?;
@@ -107,11 +103,8 @@ pub fn handler(ctx: Context<AppendMetadataItem>, args: AppendMetadataItemArgs) -
                         value: args.value,
                     },
                 );
-                metadata.collection.collections.remove(collection_index);
-                metadata
-                    .collection
-                    .collections
-                    .insert(collection_index, collection);
+                metadata.collections.remove(collection_index);
+                metadata.collections.insert(collection_index, collection);
             }
         };
     }

--- a/programs/mythic_metadata/src/instructions/auth/revoke.rs
+++ b/programs/mythic_metadata/src/instructions/auth/revoke.rs
@@ -49,7 +49,7 @@ pub fn handler(ctx: Context<RevokeCollectionUpdateAuthority>) -> Result<()> {
     let update_authority = &ctx.accounts.update_authority;
 
     // Check if root collection and collection is same to update root_collection.update_authority
-    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+    if check_collection_metadata_equality(metadata_metadata_key, collection_metadata_key) {
         verify_metadata_update_authority(&metadata, update_authority.key)?;
         metadata.update_authority = None;
     } else {

--- a/programs/mythic_metadata/src/instructions/auth/revoke.rs
+++ b/programs/mythic_metadata/src/instructions/auth/revoke.rs
@@ -11,11 +11,11 @@ pub struct RevokeCollectionUpdateAuthority<'info> {
     pub update_authority: Signer<'info>,
     #[account(
         mut,
-        constraint = metadata.collection.metadata_key_id.eq(&root_collection_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
+        constraint = metadata.metadata_key_id.eq(&metadata_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
         seeds = [
             PREFIX,
             METADATA,
-            root_collection_metadata_key.key().as_ref(),
+            metadata_metadata_key.key().as_ref(),
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
@@ -26,11 +26,11 @@ pub struct RevokeCollectionUpdateAuthority<'info> {
         seeds = [
             PREFIX,
             METADATA_KEY,
-            &root_collection_metadata_key.id.to_le_bytes()
+            &metadata_metadata_key.id.to_le_bytes()
         ],
-        bump = root_collection_metadata_key.bump,
+        bump = metadata_metadata_key.bump,
     )]
-    pub root_collection_metadata_key: Account<'info, MetadataKey>,
+    pub metadata_metadata_key: Account<'info, MetadataKey>,
     #[account(
         seeds = [
             PREFIX,
@@ -44,30 +44,24 @@ pub struct RevokeCollectionUpdateAuthority<'info> {
 
 pub fn handler(ctx: Context<RevokeCollectionUpdateAuthority>) -> Result<()> {
     let metadata = &mut ctx.accounts.metadata;
-    let root_collection_metadata_key = &ctx.accounts.root_collection_metadata_key;
+    let metadata_metadata_key = &ctx.accounts.metadata_metadata_key;
     let collection_metadata_key = &ctx.accounts.collection_metadata_key;
     let update_authority = &ctx.accounts.update_authority;
 
     // Check if root collection and collection is same to update root_collection.update_authority
-    if check_collection_root_collection_equality(
-        root_collection_metadata_key,
-        collection_metadata_key,
-    ) {
-        verify_root_collection_update_authority(&metadata.collection, update_authority.key)?;
-        metadata.collection.update_authority = None;
+    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+        verify_metadata_update_authority(&metadata, update_authority.key)?;
+        metadata.update_authority = None;
     } else {
         let (collection_index, mut collection) = verify_collection_update_authority(
-            &metadata.collection,
+            &metadata,
             collection_metadata_key.id,
             &update_authority.key(),
         )?;
 
         collection.update_authority = None;
-        metadata.collection.collections.remove(collection_index);
-        metadata
-            .collection
-            .collections
-            .insert(collection_index, collection);
+        metadata.collections.remove(collection_index);
+        metadata.collections.insert(collection_index, collection);
     }
 
     metadata.validate()?;

--- a/programs/mythic_metadata/src/instructions/auth/set.rs
+++ b/programs/mythic_metadata/src/instructions/auth/set.rs
@@ -52,7 +52,7 @@ pub fn handler(
     let update_authority = &ctx.accounts.update_authority;
 
     // Check if root collection and collection is same to update root_collection.update_authority
-    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+    if check_collection_metadata_equality(metadata_metadata_key, collection_metadata_key) {
         verify_metadata_update_authority(&metadata, update_authority.key)?;
         metadata.update_authority = Some(args.new_update_authority);
     } else {

--- a/programs/mythic_metadata/src/instructions/create/metadata.rs
+++ b/programs/mythic_metadata/src/instructions/create/metadata.rs
@@ -15,17 +15,11 @@ pub struct CreateMetadata<'info> {
     #[account(
         init,
         payer = payer,
-        space = Metadata::size(&MetadataRootCollection {
-            collections: vec![],
-            items: vec![],
-            metadata_key_id: root_collection_metadata_key.id,
-            update_slot: Clock::get()?.slot,
-            update_authority: args.update_authority
-        }),
+        space = Metadata::size(&[], &[]),
         seeds = [
             PREFIX,
             METADATA,
-            root_collection_metadata_key.key().as_ref(),
+            metadata_metadata_key.key().as_ref(),
             issuing_authority.key().as_ref(),
             args.subject.as_ref()
         ],
@@ -36,11 +30,11 @@ pub struct CreateMetadata<'info> {
         seeds = [
             PREFIX,
             METADATA_KEY,
-            &root_collection_metadata_key.id.to_le_bytes()
+            &metadata_metadata_key.id.to_le_bytes()
         ],
-        bump = root_collection_metadata_key.bump,
+        bump = metadata_metadata_key.bump,
     )]
-    pub root_collection_metadata_key: Account<'info, MetadataKey>,
+    pub metadata_metadata_key: Account<'info, MetadataKey>,
     pub system_program: Program<'info, System>,
 }
 
@@ -53,16 +47,16 @@ pub fn handler(ctx: Context<CreateMetadata>, args: CreateMetadataArgs) -> Result
     let metadata = &mut ctx.accounts.metadata;
     metadata.set_inner(Metadata {
         bump: ctx.bumps.metadata,
-        collection: MetadataRootCollection {
-            collections: vec![],
-            items: vec![],
-            metadata_key_id: ctx.accounts.root_collection_metadata_key.id,
-            update_authority,
-            update_slot: Clock::get()?.slot,
-        },
+        collections: vec![],
+        items: vec![],
+        metadata_key_id: ctx.accounts.metadata_metadata_key.id,
+        update_authority,
+        update_slot: Clock::get()?.slot,
         issuing_authority: ctx.accounts.issuing_authority.key(),
         subject,
     });
+
+    metadata.validate()?;
 
     Ok(())
 }

--- a/programs/mythic_metadata/src/instructions/remove/collection.rs
+++ b/programs/mythic_metadata/src/instructions/remove/collection.rs
@@ -11,11 +11,11 @@ pub struct RemoveMetadataCollection<'info> {
     pub update_authority: Signer<'info>,
     #[account(
         mut,
-        constraint = metadata.collection.metadata_key_id.eq(&root_collection_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
+        constraint = metadata.metadata_key_id.eq(&metadata_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
         seeds = [
             PREFIX,
             METADATA,
-            root_collection_metadata_key.key().as_ref(),
+            metadata_metadata_key.key().as_ref(),
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
@@ -26,11 +26,11 @@ pub struct RemoveMetadataCollection<'info> {
         seeds = [
             PREFIX,
             METADATA_KEY,
-            &root_collection_metadata_key.id.to_le_bytes()
+            &metadata_metadata_key.id.to_le_bytes()
         ],
-        bump = root_collection_metadata_key.bump,
+        bump = metadata_metadata_key.bump,
     )]
-    pub root_collection_metadata_key: Account<'info, MetadataKey>,
+    pub metadata_metadata_key: Account<'info, MetadataKey>,
     #[account(
         seeds = [
             PREFIX,
@@ -48,7 +48,7 @@ pub fn handler(ctx: Context<RemoveMetadataCollection>) -> Result<()> {
 
     // Verify metadata root collection update authority
     require!(
-        verify_root_collection_update_authority(&metadata.collection, update_authority)?,
+        verify_metadata_update_authority(&metadata, update_authority)?,
         MythicMetadataError::Unauthorized
     );
 
@@ -56,12 +56,11 @@ pub fn handler(ctx: Context<RemoveMetadataCollection>) -> Result<()> {
     let collection_metadata_key = &ctx.accounts.collection_metadata_key;
 
     match metadata
-        .collection
         .collections
         .binary_search_by_key(&collection_metadata_key.id, |collection| {
             collection.metadata_key_id
         }) {
-        Ok(collection_index) => metadata.collection.collections.remove(collection_index),
+        Ok(collection_index) => metadata.collections.remove(collection_index),
         Err(_) => return err!(MythicMetadataError::MetadataCollectionNonExistent),
     };
 

--- a/programs/mythic_metadata/src/instructions/remove/item.rs
+++ b/programs/mythic_metadata/src/instructions/remove/item.rs
@@ -59,7 +59,7 @@ pub fn handler(ctx: Context<RemoveMetadataItem>) -> Result<()> {
     let update_authority = &ctx.accounts.update_authority;
 
     // Check if metadata item is to be removed in root collection
-    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+    if check_collection_metadata_equality(metadata_metadata_key, collection_metadata_key) {
         verify_metadata_update_authority(&metadata, &update_authority.key())?;
 
         match metadata

--- a/programs/mythic_metadata/src/instructions/remove/item.rs
+++ b/programs/mythic_metadata/src/instructions/remove/item.rs
@@ -11,11 +11,11 @@ pub struct RemoveMetadataItem<'info> {
     pub update_authority: Signer<'info>,
     #[account(
         mut,
-        constraint = metadata.collection.metadata_key_id.eq(&root_collection_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
+        constraint = metadata.metadata_key_id.eq(&metadata_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
         seeds = [
             PREFIX,
             METADATA,
-            root_collection_metadata_key.key().as_ref(),
+            metadata_metadata_key.key().as_ref(),
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
@@ -26,11 +26,11 @@ pub struct RemoveMetadataItem<'info> {
         seeds = [
             PREFIX,
             METADATA_KEY,
-            &root_collection_metadata_key.id.to_le_bytes()
+            &metadata_metadata_key.id.to_le_bytes()
         ],
-        bump = root_collection_metadata_key.bump,
+        bump = metadata_metadata_key.bump,
     )]
-    pub root_collection_metadata_key: Account<'info, MetadataKey>,
+    pub metadata_metadata_key: Account<'info, MetadataKey>,
     #[account(
         seeds = [
             PREFIX,
@@ -53,29 +53,25 @@ pub struct RemoveMetadataItem<'info> {
 
 pub fn handler(ctx: Context<RemoveMetadataItem>) -> Result<()> {
     let metadata = &mut ctx.accounts.metadata;
-    let root_collection_metadata_key = &ctx.accounts.root_collection_metadata_key;
+    let metadata_metadata_key = &ctx.accounts.metadata_metadata_key;
     let collection_metadata_key = &ctx.accounts.collection_metadata_key;
     let item_metadata_key = &ctx.accounts.item_metadata_key;
     let update_authority = &ctx.accounts.update_authority;
 
     // Check if metadata item is to be removed in root collection
-    if check_collection_root_collection_equality(
-        root_collection_metadata_key,
-        collection_metadata_key,
-    ) {
-        verify_root_collection_update_authority(&metadata.collection, &update_authority.key())?;
+    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+        verify_metadata_update_authority(&metadata, &update_authority.key())?;
 
         match metadata
-            .collection
             .items
             .binary_search_by_key(&item_metadata_key.id, |item| item.metadata_key_id)
         {
-            Ok(item_index) => metadata.collection.items.remove(item_index),
+            Ok(item_index) => metadata.items.remove(item_index),
             Err(_) => return err!(MythicMetadataError::MetadataItemNonExistent),
         };
     } else {
         let (collection_index, mut collection) = verify_collection_update_authority(
-            &metadata.collection,
+            &metadata,
             collection_metadata_key.id,
             &update_authority.key(),
         )?;
@@ -86,11 +82,8 @@ pub fn handler(ctx: Context<RemoveMetadataItem>) -> Result<()> {
         {
             Ok(item_index) => {
                 collection.items.remove(item_index);
-                metadata.collection.collections.remove(collection_index);
-                metadata
-                    .collection
-                    .collections
-                    .insert(collection_index, collection);
+                metadata.collections.remove(collection_index);
+                metadata.collections.insert(collection_index, collection);
             }
             Err(_) => return err!(MythicMetadataError::MetadataItemNonExistent),
         };

--- a/programs/mythic_metadata/src/instructions/update/item.rs
+++ b/programs/mythic_metadata/src/instructions/update/item.rs
@@ -11,11 +11,11 @@ pub struct UpdateMetadataItem<'info> {
     pub update_authority: Signer<'info>,
     #[account(
         mut,
-        constraint = metadata.collection.metadata_key_id.eq(&root_collection_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
+        constraint = metadata.metadata_key_id.eq(&metadata_metadata_key.id) @ MythicMetadataError::InvalidMetadataKey,
         seeds = [
             PREFIX,
             METADATA,
-            root_collection_metadata_key.key().as_ref(),
+            metadata_metadata_key.key().as_ref(),
             metadata.issuing_authority.as_ref(),
             metadata.subject.as_ref()
         ],
@@ -26,11 +26,11 @@ pub struct UpdateMetadataItem<'info> {
         seeds = [
             PREFIX,
             METADATA_KEY,
-            &root_collection_metadata_key.id.to_le_bytes()
+            &metadata_metadata_key.id.to_le_bytes()
         ],
-        bump = root_collection_metadata_key.bump,
+        bump = metadata_metadata_key.bump,
     )]
-    pub root_collection_metadata_key: Account<'info, MetadataKey>,
+    pub metadata_metadata_key: Account<'info, MetadataKey>,
     #[account(
         seeds = [
             PREFIX,
@@ -53,28 +53,24 @@ pub struct UpdateMetadataItem<'info> {
 
 pub fn handler(ctx: Context<UpdateMetadataItem>, args: UpdateMetadataItemArgs) -> Result<()> {
     let metadata = &mut ctx.accounts.metadata;
-    let root_collection_metadata_key = &ctx.accounts.root_collection_metadata_key;
+    let metadata_metadata_key = &ctx.accounts.metadata_metadata_key;
     let collection_metadata_key = &ctx.accounts.collection_metadata_key;
     let item_metadata_key = &ctx.accounts.item_metadata_key;
     let update_authority = &ctx.accounts.update_authority;
 
     // Check if metadata item is to be updated in root collection
-    if check_collection_root_collection_equality(
-        root_collection_metadata_key,
-        collection_metadata_key,
-    ) {
-        verify_root_collection_update_authority(&metadata.collection, &update_authority.key())?;
+    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+        verify_metadata_update_authority(&metadata, &update_authority.key())?;
 
         match metadata
-            .collection
             .items
             .binary_search_by_key(&item_metadata_key.id, |item| item.metadata_key_id)
         {
             Ok(item_index) => {
                 let slot = Clock::get()?.slot;
-                metadata.collection.items.remove(item_index);
-                metadata.collection.update_slot = slot;
-                metadata.collection.items.insert(
+                metadata.items.remove(item_index);
+                metadata.update_slot = slot;
+                metadata.items.insert(
                     item_index,
                     MetadataItem {
                         metadata_key_id: item_metadata_key.id,
@@ -87,7 +83,7 @@ pub fn handler(ctx: Context<UpdateMetadataItem>, args: UpdateMetadataItemArgs) -
         };
     } else {
         let (collection_index, mut collection) = verify_collection_update_authority(
-            &metadata.collection,
+            &metadata,
             collection_metadata_key.id,
             &update_authority.key(),
         )?;
@@ -108,11 +104,8 @@ pub fn handler(ctx: Context<UpdateMetadataItem>, args: UpdateMetadataItemArgs) -
                         value: args.new_value,
                     },
                 );
-                metadata.collection.collections.remove(collection_index);
-                metadata
-                    .collection
-                    .collections
-                    .insert(collection_index, collection);
+                metadata.collections.remove(collection_index);
+                metadata.collections.insert(collection_index, collection);
             }
             Err(_) => return err!(MythicMetadataError::MetadataItemNonExistent),
         };

--- a/programs/mythic_metadata/src/instructions/update/item.rs
+++ b/programs/mythic_metadata/src/instructions/update/item.rs
@@ -7,7 +7,7 @@ use crate::utils::*;
 
 #[derive(Accounts)]
 pub struct UpdateMetadataItem<'info> {
-    #[account()]
+    #[account(mut)]
     pub update_authority: Signer<'info>,
     #[account(
         mut,
@@ -49,6 +49,7 @@ pub struct UpdateMetadataItem<'info> {
         bump = item_metadata_key.bump,
     )]
     pub item_metadata_key: Account<'info, MetadataKey>,
+    pub system_program: Program<'info, System>,
 }
 
 pub fn handler(ctx: Context<UpdateMetadataItem>, args: UpdateMetadataItemArgs) -> Result<()> {
@@ -58,8 +59,8 @@ pub fn handler(ctx: Context<UpdateMetadataItem>, args: UpdateMetadataItemArgs) -
     let item_metadata_key = &ctx.accounts.item_metadata_key;
     let update_authority = &ctx.accounts.update_authority;
 
-    // Check if metadata item is to be updated in root collection
-    if check_collection_root_collection_equality(metadata_metadata_key, collection_metadata_key) {
+    // Check if metadata item is to be updated in main metadata
+    if check_collection_metadata_equality(metadata_metadata_key, collection_metadata_key) {
         verify_metadata_update_authority(&metadata, &update_authority.key())?;
 
         match metadata
@@ -110,6 +111,16 @@ pub fn handler(ctx: Context<UpdateMetadataItem>, args: UpdateMetadataItemArgs) -
             Err(_) => return err!(MythicMetadataError::MetadataItemNonExistent),
         };
     }
+
+    let metadata_new_size = Metadata::size(&metadata.items, &metadata.collections);
+    realloc_account(
+        metadata.to_account_info(),
+        metadata_new_size,
+        ctx.accounts.update_authority.to_account_info(),
+        ctx.accounts.system_program.to_account_info(),
+    )?;
+
+    metadata.validate()?;
 
     Ok(())
 }

--- a/programs/mythic_metadata/src/utils.rs
+++ b/programs/mythic_metadata/src/utils.rs
@@ -6,12 +6,12 @@ use anchor_lang::{
 use crate::errors::*;
 use crate::state::*;
 
-pub fn check_collection_root_collection_equality(
-    root_collection_metadata_key: &Account<MetadataKey>,
+pub fn check_collection_metadata_equality(
+    metadata_collection_metadata_key: &Account<MetadataKey>,
     collection_metadata_key: &Account<MetadataKey>,
 ) -> bool {
-    root_collection_metadata_key.key() == collection_metadata_key.key()
-        && root_collection_metadata_key.id == collection_metadata_key.id
+    metadata_collection_metadata_key.key() == collection_metadata_key.key()
+        && metadata_collection_metadata_key.id == collection_metadata_key.id
 }
 
 pub fn verify_metadata_update_authority(

--- a/programs/mythic_metadata/src/utils.rs
+++ b/programs/mythic_metadata/src/utils.rs
@@ -14,15 +14,15 @@ pub fn check_collection_root_collection_equality(
         && root_collection_metadata_key.id == collection_metadata_key.id
 }
 
-pub fn verify_root_collection_update_authority(
-    root_collection: &MetadataRootCollection,
+pub fn verify_metadata_update_authority(
+    metadata: &Metadata,
     update_authority: &Pubkey,
 ) -> Result<bool> {
-    if root_collection.update_authority.is_none() {
+    if metadata.update_authority.is_none() {
         return err!(MythicMetadataError::ImmutableMetadata);
     }
 
-    if let Some(expected_update_authority) = root_collection.update_authority {
+    if let Some(expected_update_authority) = metadata.update_authority {
         if expected_update_authority.ne(&update_authority) {
             return Ok(false);
         }
@@ -31,21 +31,21 @@ pub fn verify_root_collection_update_authority(
 }
 
 pub fn verify_collection_update_authority(
-    root_collection: &MetadataRootCollection,
+    metadata: &Metadata,
     collection_metadata_key_id: u64,
     update_authority: &Pubkey,
 ) -> Result<(usize, MetadataCollection)> {
-    match root_collection
+    match metadata
         .collections
         .binary_search_by_key(&collection_metadata_key_id, |collection| {
             collection.metadata_key_id
         }) {
         Ok(collection_index) => {
-            let collection = root_collection.collections.get(collection_index).unwrap();
+            let collection = metadata.collections.get(collection_index).unwrap();
 
             if collection.update_authority.is_none() {
                 require!(
-                    verify_root_collection_update_authority(root_collection, update_authority)?,
+                    verify_metadata_update_authority(metadata, update_authority)?,
                     MythicMetadataError::Unauthorized
                 );
                 return Ok((collection_index, collection.clone()));
@@ -53,7 +53,7 @@ pub fn verify_collection_update_authority(
                 let collection_update_authority = collection.update_authority.unwrap();
                 if collection_update_authority.ne(&update_authority) {
                     require!(
-                        verify_root_collection_update_authority(root_collection, update_authority)?,
+                        verify_metadata_update_authority(metadata, update_authority)?,
                         MythicMetadataError::Unauthorized
                     );
                 }

--- a/tests/mythic_metadata.ts
+++ b/tests/mythic_metadata.ts
@@ -76,7 +76,7 @@ describe("metadata", () => {
   const metadataRootCollectionAuthKeypair = new Keypair();
   const metadataCollectionUpdateAuthKeypair = new Keypair();
 
-  let metadataRootCollectionMetadataKey: PublicKey;
+  let metadataMetadataKey: PublicKey;
   let metadataCollectionMetadataKey: PublicKey;
   let metadataItemMetadataKey: PublicKey;
 
@@ -115,10 +115,10 @@ describe("metadata", () => {
         programId
       );
 
-      metadataRootCollectionMetadataKey = metadataKeyBatch[0];
+      metadataMetadataKey = metadataKeyBatch[0];
       const bump = metadataKeyBatch[1];
 
-      let metadataRootCollectionMetadataKeyData;
+      let metadataMetadataKeyData;
       before(async () => {
         await mythicMetadataProgram.methods
           .createMetadataKey({
@@ -129,7 +129,7 @@ describe("metadata", () => {
             id: new anchor.BN(metadataRootCollectionMetadataId),
           })
           .accountsStrict({
-            metadataKey: metadataRootCollectionMetadataKey,
+            metadataKey: metadataMetadataKey,
             namespaceAuthority: metadataKeyAuthKeypair.publicKey,
             payer: wallet.publicKey,
             systemProgram: SystemProgram.programId,
@@ -140,44 +140,40 @@ describe("metadata", () => {
           .signers([metadataKeyAuthKeypair])
           .rpc(confirmOptions);
 
-        metadataRootCollectionMetadataKeyData =
+        metadataMetadataKeyData =
           await mythicMetadataProgram.account.metadataKey.fetch(
-            metadataRootCollectionMetadataKey
+            metadataMetadataKey
           );
       });
 
       it("should have right bump", () => {
-        expect(metadataRootCollectionMetadataKeyData.bump).to.eql(bump);
+        expect(metadataMetadataKeyData.bump).to.eql(bump);
       });
 
       it("should have right namespaceAuthority", () => {
-        expect(
-          metadataRootCollectionMetadataKeyData.namespaceAuthority.toString()
-        ).to.eql(metadataKeyAuthKeypair.publicKey.toString());
+        expect(metadataMetadataKeyData.namespaceAuthority.toString()).to.eql(
+          metadataKeyAuthKeypair.publicKey.toString()
+        );
       });
 
       it("should have right name", () => {
-        expect(metadataRootCollectionMetadataKeyData.name).to.eql(name);
+        expect(metadataMetadataKeyData.name).to.eql(name);
       });
 
       it("should have right label", () => {
-        expect(metadataRootCollectionMetadataKeyData.label).to.eql(label);
+        expect(metadataMetadataKeyData.label).to.eql(label);
       });
 
       it("should have right description", () => {
-        expect(metadataRootCollectionMetadataKeyData.description).to.eql(
-          description
-        );
+        expect(metadataMetadataKeyData.description).to.eql(description);
       });
 
       it("should have right contentType", () => {
-        expect(metadataRootCollectionMetadataKeyData.contentType).to.eql(
-          contentType
-        );
+        expect(metadataMetadataKeyData.contentType).to.eql(contentType);
       });
 
       it("should have right id", () => {
-        expect(metadataRootCollectionMetadataKeyData.id.toString()).to.eql(
+        expect(metadataMetadataKeyData.id.toString()).to.eql(
           metadataRootCollectionMetadataId.toString()
         );
       });
@@ -185,7 +181,7 @@ describe("metadata", () => {
 
     describe("after creating metadata", () => {
       const metadataBatch = getMetadata(
-        metadataRootCollectionMetadataKey,
+        metadataMetadataKey,
         metadataRootCollectionAuthKeypair.publicKey,
         demoSubject,
         programId
@@ -204,7 +200,7 @@ describe("metadata", () => {
           .accountsStrict({
             issuingAuthority: metadataRootCollectionAuthKeypair.publicKey,
             metadata: metadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             payer: wallet.publicKey,
             systemProgram: SystemProgram.programId,
           })
@@ -227,7 +223,7 @@ describe("metadata", () => {
       });
 
       it("should have right updateAuthority", () => {
-        expect(metadataData.collection.updateAuthority.toString()).to.eql(
+        expect(metadataData.updateAuthority.toString()).to.eql(
           metadataRootCollectionAuthKeypair.publicKey.toString()
         );
       });
@@ -329,7 +325,7 @@ describe("metadata", () => {
           .accountsStrict({
             collectionMetadataKey: metadataCollectionMetadataKey,
             metadata: metadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             payer: metadataRootCollectionAuthKeypair.publicKey,
             updateAuthority: metadataRootCollectionAuthKeypair.publicKey,
             systemProgram: SystemProgram.programId,
@@ -340,11 +336,11 @@ describe("metadata", () => {
         metadataData = await mythicMetadataProgram.account.metadata.fetch(
           metadataKey
         );
-        collection = metadataData.collection.collections[0];
+        collection = metadataData.collections[0];
       });
 
       it("should have 1 collection in metadata", () => {
-        expect(metadataData.collection.collections.length).to.eql(1);
+        expect(metadataData.collections.length).to.eql(1);
       });
 
       it("should have right metadata key id", () => {
@@ -368,7 +364,7 @@ describe("metadata", () => {
           .accountsStrict({
             collectionMetadataKey: metadataCollectionMetadataKey,
             metadata: metadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             updateAuthority: metadataRootCollectionAuthKeypair.publicKey,
           })
           .signers([metadataRootCollectionAuthKeypair])
@@ -380,7 +376,7 @@ describe("metadata", () => {
       });
 
       it("should have updated collection update authority", () => {
-        const collection = metadataData.collection.collections[0];
+        const collection = metadataData.collections[0];
         expect(collection.updateAuthority.toString()).to.eql(
           metadataCollectionUpdateAuthKeypair.publicKey.toString()
         );
@@ -480,8 +476,9 @@ describe("metadata", () => {
             collectionMetadataKey: metadataCollectionMetadataKey,
             itemMetadataKey: metadataItemMetadataKey,
             metadata: metadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             updateAuthority: metadataCollectionUpdateAuthKeypair.publicKey,
+            systemProgram: SystemProgram.programId,
           })
           .signers([metadataCollectionUpdateAuthKeypair])
           .rpc(confirmOptions);
@@ -489,7 +486,7 @@ describe("metadata", () => {
         metadataData = await mythicMetadataProgram.account.metadata.fetch(
           metadataKey
         );
-        collection = metadataData.collection.collections[0];
+        collection = metadataData.collections[0];
         item = collection.items[0];
       });
 
@@ -524,8 +521,9 @@ describe("metadata", () => {
             collectionMetadataKey: metadataCollectionMetadataKey,
             itemMetadataKey: metadataItemMetadataKey,
             metadata: metadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             updateAuthority: metadataCollectionUpdateAuthKeypair.publicKey,
+            systemProgram: SystemProgram.programId,
           })
           .signers([metadataCollectionUpdateAuthKeypair])
           .rpc(confirmOptions);
@@ -533,7 +531,7 @@ describe("metadata", () => {
         metadataData = await mythicMetadataProgram.account.metadata.fetch(
           metadataKey
         );
-        collection = metadataData.collection.collections[0];
+        collection = metadataData.collections[0];
         item = collection.items[0];
       });
 
@@ -551,7 +549,7 @@ describe("metadata", () => {
             collectionMetadataKey: metadataCollectionMetadataKey,
             metadata: metadataKey,
             itemMetadataKey: metadataItemMetadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             updateAuthority: metadataCollectionUpdateAuthKeypair.publicKey,
           })
           .signers([metadataCollectionUpdateAuthKeypair])
@@ -563,7 +561,7 @@ describe("metadata", () => {
       });
 
       it("should have removed from collection", () => {
-        const collection = metadataData.collection.collections[0];
+        const collection = metadataData.collections[0];
         expect(collection.items.length).to.eql(0);
       });
     });
@@ -576,7 +574,7 @@ describe("metadata", () => {
           .accountsStrict({
             collectionMetadataKey: metadataCollectionMetadataKey,
             metadata: metadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             updateAuthority: metadataCollectionUpdateAuthKeypair.publicKey,
           })
           .signers([metadataCollectionUpdateAuthKeypair])
@@ -588,7 +586,7 @@ describe("metadata", () => {
       });
 
       it("should have nullified collection update authority", () => {
-        const collection = metadataData.collection.collections[0];
+        const collection = metadataData.collections[0];
         expect(collection.updateAuthority).to.be.null;
       });
     });
@@ -601,7 +599,7 @@ describe("metadata", () => {
           .accountsStrict({
             collectionMetadataKey: metadataCollectionMetadataKey,
             metadata: metadataKey,
-            rootCollectionMetadataKey: metadataRootCollectionMetadataKey,
+            metadataMetadataKey: metadataMetadataKey,
             updateAuthority: metadataRootCollectionAuthKeypair.publicKey,
           })
           .signers([metadataRootCollectionAuthKeypair])
@@ -613,7 +611,7 @@ describe("metadata", () => {
       });
 
       it("should have removed from root collection", () => {
-        expect(metadataData.collection.collections.length).to.eql(0);
+        expect(metadataData.collections.length).to.eql(0);
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,18 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@coral-xyz/anchor@^0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.30.0.tgz#52acdba504b0008f1026d3a4bbbcb2d4feb5c69e"
-  integrity sha512-qreDh5ztiRHVnCbJ+RS70NJ6aSTPBYDAgFeQ7Z5QvaT5DcDIhNyt4onOciVz2ieIE1XWePOJDDu9SbNvPGBkvQ==
+"@coral-xyz/anchor-errors@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.30.1.tgz#bdfd3a353131345244546876eb4afc0e125bec30"
+  integrity sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ==
+
+"@coral-xyz/anchor@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.30.1.tgz#17f3e9134c28cd0ea83574c6bab4e410bcecec5d"
+  integrity sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==
   dependencies:
-    "@coral-xyz/borsh" "^0.30.0"
+    "@coral-xyz/anchor-errors" "^0.30.1"
+    "@coral-xyz/borsh" "^0.30.1"
     "@noble/hashes" "^1.3.1"
     "@solana/web3.js" "^1.68.0"
     bn.js "^5.1.2"
@@ -36,10 +42,10 @@
     superstruct "^0.15.4"
     toml "^3.0.0"
 
-"@coral-xyz/borsh@^0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.30.0.tgz#3e6f23e944ef6c89f2c9cbead383358752ac5e73"
-  integrity sha512-OrcV+7N10cChhgDRUxM4iEIuwxUHHs52XD85R8cFCUqE0vbLYrcoPPPs+VF6kZ9DhdJGVW2I6DHJOp5TykyZog==
+"@coral-xyz/borsh@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.30.1.tgz#869d8833abe65685c72e9199b8688477a4f6b0e3"
+  integrity sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==
   dependencies:
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"


### PR DESCRIPTION
The `RootCollection` state is now removed and the fields inside it are now added inside `Metadata` state account